### PR TITLE
Add acquire variants for heuristic methods

### DIFF
--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -209,7 +209,7 @@ impl<T: ?Sized, R> SpinMutex<T, R> {
     /// ordering.
     #[inline(always)]
     pub fn is_locked_acquire(&self) -> bool {
-        self.lock.load(Ordering::Relaxed)
+        self.lock.load(Ordering::Acquire)
     }
 
     /// Force unlock this [`SpinMutex`].

--- a/src/mutex/spin.rs
+++ b/src/mutex/spin.rs
@@ -201,6 +201,17 @@ impl<T: ?Sized, R> SpinMutex<T, R> {
         self.lock.load(Ordering::Relaxed)
     }
 
+    /// Returns `true` if the lock is currently held.
+    ///
+    /// # Safety
+    ///
+    /// This function checks whether the mutex is locked using an acquire
+    /// ordering.
+    #[inline(always)]
+    pub fn is_locked_acquire(&self) -> bool {
+        self.lock.load(Ordering::Relaxed)
+    }
+
     /// Force unlock this [`SpinMutex`].
     ///
     /// # Safety

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -323,6 +323,16 @@ impl<T: ?Sized, R> RwLock<T, R> {
         state / READER + (state & UPGRADED) / UPGRADED
     }
 
+    /// Return the number of readers that currently hold the lock (including upgradable readers).
+    ///
+    /// # Safety
+    ///
+    /// This function loads the reader count using an acquire ordering.
+    pub fn reader_count_acquire(&self) -> usize {
+        let state = self.lock.load(Ordering::Acquire);
+        state / READER + (state & UPGRADED) / UPGRADED
+    }
+
     /// Return the number of writers that currently hold the lock.
     ///
     /// Because [`RwLock`] guarantees exclusive mutable access, this function may only return either `0` or `1`.
@@ -333,6 +343,17 @@ impl<T: ?Sized, R> RwLock<T, R> {
     /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
     pub fn writer_count(&self) -> usize {
         (self.lock.load(Ordering::Relaxed) & WRITER) / WRITER
+    }
+
+    /// Return the number of writers that currently hold the lock.
+    ///
+    /// Because [`RwLock`] guarantees exclusive mutable access, this function may only return either `0` or `1`.
+    ///
+    /// # Safety
+    ///
+    /// This function loads the writer count using an acquire ordering.
+    pub fn writer_count_acquire(&self) -> usize {
+        (self.lock.load(Ordering::Acquire) & WRITER) / WRITER
     }
 
     /// Force decrement the reader count.


### PR DESCRIPTION
Necessary for our implementation of `Mutex` and `RwLock` for deadlock prevention types in Theseus to be able to use the `EXPENSIVE` flag.

Using acquire ordering, ensures that `try_lock`, `try_read`, and `try_write` will never fail if the lock is unlocked.